### PR TITLE
move payment factory and redsys.xml from bundle to bridge.

### DIFF
--- a/Bridge/Symfony/RedsysPaymentFactory.php
+++ b/Bridge/Symfony/RedsysPaymentFactory.php
@@ -1,0 +1,66 @@
+<?php
+namespace Crevillo\Payum\Redsys\Bridge\Symfony;
+
+use Payum\Bundle\PayumBundle\DependencyInjection\Factory\Payment\AbstractPaymentFactory;
+use Payum\Core\Exception\RuntimeException;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\DefinitionDecorator;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+
+class RedsysPaymentFactory extends AbstractPaymentFactory
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function create(ContainerBuilder $container, $contextName, array $config)
+    {
+        if (false == class_exists('\Crevillo\Payum\Redsys\PaymentFactory')) {
+            throw new RuntimeException('Cannot find redsys payment factory class');
+        }
+
+        $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/Resources/config'));
+        $loader->load('redsys.xml');
+
+        return parent::create($container, $contextName, $config);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'redsys';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addConfiguration(ArrayNodeDefinition $builder)
+    {
+        parent::addConfiguration($builder);
+
+        $builder->children()
+            ->scalarNode('merchant_code')->isRequired()->cannotBeEmpty()->end()
+            ->scalarNode('terminal')->isRequired()->cannotBeEmpty()->end()
+            ->scalarNode('secret_key')->isRequired()->cannotBeEmpty()->end()
+            ->scalarNode('sandbox')->isRequired()->cannotBeEmpty()->end()
+            ->end();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function addApis(Definition $paymentDefinition, ContainerBuilder $container, $contextName, array $config)
+    {
+        $apiDefinition = new DefinitionDecorator('payum.redsys.api.prototype');
+        $apiDefinition->replaceArgument(0, $config);
+        $apiDefinition->setPublic(true);
+        $apiId = 'payum.context.'.$contextName.'.api';
+        $container->setDefinition($apiId, $apiDefinition);
+        $paymentDefinition->addMethodCall('addApi', array(new Reference($apiId)));
+    }
+}

--- a/Bridge/Symfony/Resources/config/redsys.xml
+++ b/Bridge/Symfony/Resources/config/redsys.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="payum.redsys.api.class">Crevillo\Payum\Redsys\Api</parameter>
+        <parameter key="payum.redsys.action.capture.class">Crevillo\Payum\Redsys\Action\CaptureAction</parameter>
+        <parameter key="payum.redsys.action.fill_order_details.class">Crevillo\Payum\Redsys\Action\FillOrderDetailsAction</parameter>
+        <parameter key="payum.redsys.action.status.class">Crevillo\Payum\Redsys\Action\StatusAction</parameter>
+    </parameters>
+
+    <services>
+        <service
+            id="payum.redsys.api.prototype"
+            class="%payum.redsys.api.class%"
+            public="false"
+        >
+            <argument type="collection">
+                <!-- It is template service. The real service will be created by RedsysPaymentFactory -->
+            </argument>
+        </service>
+
+        <service
+            id="payum.redsys.action.capture"
+            class="%payum.redsys.action.capture.class%"
+            public="false"
+        >
+            <tag name="payum.action" factory="redsys" />
+        </service>
+
+        <service
+            id="payum.redsys.action.fill_order_details"
+            class="%payum.redsys.action.fill_order_details.class%"
+            public="false"
+        >
+            <argument type="service" id="payum.security.token_factory" />
+            <tag name="payum.action" factory="redsys" />
+        </service>
+
+        <service
+            id="payum.redsys.action.status"
+            class="%payum.redsys.action.status.class%"
+            public="false"
+        >
+            <tag name="payum.action" factory="redsys" />
+        </service>
+
+    </services>
+</container>


### PR DESCRIPTION
There is no need in the whole bundle, the factory and services xml could be stored in the lib itself. Same approach we did here https://github.com/locastic/TcomPayWayPayum/tree/master/src/Locastic/TcomPayWayPayum/Bridge

And in your app you can add it:

``` php
<?php

namespace Acme\RedsysBundle;

use Crevillo\Payum\Redsys\Bridge\Symfony\RedsysPaymentFactory;
use Symfony\Component\DependencyInjection\ContainerBuilder;
use Symfony\Component\HttpKernel\Bundle\Bundle;

class AcmeRedsysBundle extends Bundle
{
    /**
     * {@inheritDoc}
     */
    public function build(ContainerBuilder $container)
    {
        parent::build($container);

        /** @var $extension \Payum\Bundle\PayumBundle\DependencyInjection\PayumExtension */
        $extension = $container->getExtension('payum');

        $extension->addPaymentFactory(new RedsysPaymentFactory);
    }
}

```
