### PR TITLE
Changed order number validation to regular expression

### DIFF
--- a/Api.php
+++ b/Api.php
@@ -138,11 +138,7 @@ class Api
         // add 0 to the left in case length of the order number is less than 4
         $orderNumber = str_pad($orderNumber, self::ORDER_NUMBER_MINIMUM_LENGTH, '0', STR_PAD_LEFT);
 
-        $firstPartOfTheOrderNumber = substr($orderNumber, 0, self::ORDER_NUMBER_MINIMUM_LENGTH);
-        $secondPartOfTheOrderNumber = substr($orderNumber, self::ORDER_NUMBER_MINIMUM_LENGTH, strlen($orderNumber));
-
-        if (!ctype_digit($firstPartOfTheOrderNumber) ||
-            (!empty($secondPartOfTheOrderNumber) && !ctype_alnum($secondPartOfTheOrderNumber))) {
+        if (!preg_match('/^[0-9]{4}[a-z0-9]{0,12}$/i', $orderNumber)) {
             throw new LogicException('The payment gateway doesn\'t allow order numbers with this format.');
         }
 

--- a/Tests/ApiTest.php
+++ b/Tests/ApiTest.php
@@ -252,6 +252,17 @@ class ApiTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function shortOrderNumberProvider()
+    {
+        return array(
+            array('1', '0001'),
+            array('12', '0012'),
+            array('123', '0123'),
+            array('1234', '1234'),
+            array('1234a', '1234a')
+        );
+    }
+
     /**
      * @test
      *
@@ -271,15 +282,34 @@ class ApiTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($correctedOrderNumber, $api->ensureCorrectOrderNumber($orderNumber));
     }
 
-    public function shortOrderNumberProvider()
+    public function validOrderNumberProvider()
     {
         return array(
-            array('1', '0001'),
-            array('12', '0012'),
-            array('123', '0123'),
-            array('1234', '1234'),
-            array('1234a', '1234a')
+            array('1234'),
+            array('123412341234'),
+            array('1234aA'),
+            array('1234AABBCCDD'),
+            array('1234abcdefgh')
         );
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider validOrderNumberProvider
+     */
+    public function shouldReturnOrderNumberPassedIfValid($orderNumber)
+    {
+        $options = array(
+            'merchant_code' => 'a_merchant_code',
+            'terminal' => 'a_terminal',
+            'secret_key' => 'a_secret_key',
+            'sandbox' => true,
+        );
+
+        $api = new Api($options);
+
+        $this->assertEquals($orderNumber, $api->ensureCorrectOrderNumber($orderNumber));
     }
 
     /**


### PR DESCRIPTION
Added a test to ensure api is returning the passed order number if its valid too and changed the validation to a `preg_match`
ping @makasim 
