### PR TITLE
Added user canceled code to Ds_Response checking to mark the payment …

### DIFF
--- a/Action/StatusAction.php
+++ b/Action/StatusAction.php
@@ -32,7 +32,7 @@ class StatusAction implements ActionInterface
             return;
         }
 
-        if (Api::DS_RESPONSE_CANCELED == $model['Ds_Response']) {
+        if (in_array($model['Ds_Response'], array(Api::DS_RESPONSE_CANCELED, Api::DS_RESPONSE_USER_CANCELED))) {
             $request->markCanceled();
 
             return;

--- a/Api.php
+++ b/Api.php
@@ -15,6 +15,8 @@ class Api
 
     const DS_RESPONSE_CANCELED = '0184';
 
+    const DS_RESPONSE_USER_CANCELED = '9915';
+
     const ORDER_NUMBER_MINIMUM_LENGTH = 4;
 
     const ORDER_NUMBER_MAXIMUM_LENGHT = 12;


### PR DESCRIPTION
…as canceled

the 9915 code is not taken in account, witch indicates that a user has cancelled the op