### PR TITLE
SHA256 Migration

### DIFF
--- a/Action/ConvertPaymentAction.php
+++ b/Action/ConvertPaymentAction.php
@@ -23,7 +23,7 @@ class ConvertPaymentAction implements ActionInterface, ApiAwareInterface
     public function setApi($api)
     {
         if (false == $api instanceof Api) {
-            throw new UnsupportedApiException( 'Not supported.' );
+            throw new UnsupportedApiException('Not supported.');
         }
 
         $this->api = $api;
@@ -40,20 +40,19 @@ class ConvertPaymentAction implements ActionInterface, ApiAwareInterface
 
         /** @var PaymentInterface $payment */
         $payment = $request->getSource();
+
         $details = ArrayObject::ensureArrayObject($payment->getDetails());
 
         $details->defaults(array(
+            'Ds_Merchant_Amount' => $payment->getTotalAmount(),
+            'Ds_Merchant_Order' => $this->api->ensureCorrectOrderNumber($payment->getNumber()),
+            'Ds_Merchant_MerchantCode' => $this->api->getMerchantCode(),
+            'Ds_Merchant_Currency' => $this->api->getISO4127($payment->getCurrencyCode()),
             'Ds_Merchant_TransactionType' => Api::TRANSACTIONTYPE_AUTHORIZATION,
-            'Ds_Merchant_ConsumerLanguage' => Api::CONSUMERLANGUAGE_SPANISH,
+            'Ds_Merchant_Terminal' => $this->api->getMerchantTerminalCode(),
         ));
 
-        $details['Ds_Merchant_Amount'] = $payment->getTotalAmount();
-        $details['Ds_Merchant_Currency'] = $this->api->getISO4127($payment->getCurrencyCode());
-        $details['Ds_Merchant_Order'] = $this->api->ensureCorrectOrderNumber($payment->getNumber());
-        $details['Ds_Merchant_MerchantCode'] = $this->api->getMerchantCode();
-        $details['Ds_Merchant_Terminal'] = $this->api->getMerchantTerminalCode();
-
-        $request->setResult((array) $details);
+        $request->setResult((array)$details);
     }
 
     /**
@@ -64,7 +63,6 @@ class ConvertPaymentAction implements ActionInterface, ApiAwareInterface
         return
             $request instanceof Convert &&
             'array' == $request->getTo() &&
-            $request->getSource() instanceof PaymentInterface
-        ;
+            $request->getSource() instanceof PaymentInterface;
     }
 }

--- a/Action/StatusAction.php
+++ b/Action/StatusAction.php
@@ -15,24 +15,25 @@ class StatusAction implements ActionInterface
     public function execute($request)
     {
         /** @var $request GetStatusInterface */
-        RequestNotSupportedException::assertSupports( $this, $request );
+        RequestNotSupportedException::assertSupports($this, $request);
 
-        $model = ArrayObject::ensureArrayObject( $request->getModel() );
+        $model = ArrayObject::ensureArrayObject($request->getModel());
 
-        if (false == $model['Ds_Merchant_MerchantSignature']) {
+        if (null == $model['Ds_Response']) {
             $request->markNew();
 
             return;
         }
 
 
-        if ($model['Ds_Merchant_MerchantSignature'] && null === $model['Ds_Response']) {
+        if ($model['Ds_AuthorisationCode'] && null === $model['Ds_Response']) {
             $request->markPending();
 
             return;
         }
 
-        if (in_array($model['Ds_Response'], array(Api::DS_RESPONSE_CANCELED, Api::DS_RESPONSE_USER_CANCELED))) {
+        if (in_array($model['Ds_Response'],
+            array(Api::DS_RESPONSE_CANCELED, Api::DS_RESPONSE_USER_CANCELED))) {
             $request->markCanceled();
 
             return;

--- a/Tests/ApiTest.php
+++ b/Tests/ApiTest.php
@@ -133,7 +133,7 @@ class ApiTest extends \PHPUnit_Framework_TestCase
 
         $api = new Api($options);
 
-        $this->assertEquals('https://sis-t.sermepa.es:25443/sis/realizarPago', $api->getRedsysUrl());
+        $this->assertEquals('https://sis-t.redsys.es:25443/sis/realizarPago', $api->getRedsysUrl());
     }
 
     /**
@@ -150,7 +150,7 @@ class ApiTest extends \PHPUnit_Framework_TestCase
 
         $api = new Api($options);
 
-        $this->assertEquals('https://sis.sermepa.es/sis/realizarPago', $api->getRedsysUrl() );
+        $this->assertEquals('https://sis.redsys.es/sis/realizarPago', $api->getRedsysUrl() );
     }
 
     /**


### PR DESCRIPTION
Redsys is chaging its encryption algorithm. From 23rd (supposedly) all request made with sha1 will no longer work and all commerce using redsys payment are advised to migrate to this new encryption way. 

Basically there are changes in what you send to the bank and what you received to the bank. before you were sending everything but now you can only send three things, 

The bank will reply with a signed request and after decoding it you can get the Ds_Response need to work with the GetHumanStatus Action. (Before Ds_Response were received as a post param)

ping @makasim 