### PR TITLE
Modify getTargetUrl()

### DIFF
--- a/Action/CaptureAction.php
+++ b/Action/CaptureAction.php
@@ -79,11 +79,11 @@ class CaptureAction implements ActionInterface, ApiAwareInterface, GenericTokenF
 
         if (false == $postData['Ds_Merchant_UrlOK'] && $request->getToken()) {
             $postData['Ds_Merchant_UrlOK'] = $request->getToken()
-                ->getTargetUrl();
+                ->getAfterUrl();
         }
         if (false == $postData['Ds_Merchant_UrlKO'] && $request->getToken()) {
             $postData['Ds_Merchant_UrlKO'] = $request->getToken()
-                ->getTargetUrl();
+                ->getAfterUrl();
         }
 
         $details['Ds_SignatureVersion'] = Api::SIGNATURE_VERSION;


### PR DESCRIPTION
I think the url for KO ans OK is getAfterUrl, because if you leave getTargetUrl() after pay the gateway redirect to capture and you go to the payment gateway with the same order number